### PR TITLE
Fix script name in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,9 @@ Testing Symbolication API
 -------------------------
 
 1. Run::
-   
+
        $ make shell
-       app@...:/app$ python bin/symbolicate.py stacks HOST
+       app@...:/app$ python bin/symbolication.py stacks https://HOST/
 
    to run it against HOST.
 


### PR DESCRIPTION
The script to test the symbolication API is called symbolication.py, no symbolicate.py. The latter also exists, which made this typo confusing. I also added a protocol to the HOST on the command line to make clear it needs to be a URL.