### PR TITLE
Add new GCP envs to Eliot load tests.

### DIFF
--- a/locust-eliot/loadtest_eliot.sh
+++ b/locust-eliot/loadtest_eliot.sh
@@ -5,75 +5,17 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Usage: ./loadtest_eliot.sh ENV [RUNNAME]
-#
-# Run it in the Docker container in the locust-eliot/ directory.
 
-AWS_STAGE_HOST="https://symbolication.stage.mozaws.net"
-AWS_PROD_HOST="https://symbolication.services.mozilla.com"
+cd "$(dirname -- "$0")"
+. loadtest_functions.sh
 
-GCP_STAGE_HOST="https://stage.eliot.nonprod.dataservices.mozgcp.net"
-GCP_PROD_HOST="https://prod.eliot.prod.dataservices.mozgcp.net"
-
-
-if [[ "$1" == "aws-stage" ]]; then
-    export HOST=${AWS_STAGE_HOST}
-
-elif [[ "$1" == "aws-prod" ]]; then
-    export HOST=${AWS_PROD_HOST}
-
-elif [[ "$1" == "gcp-stage" ]]; then
-    export HOST=${GCP_STAGE_HOST}
-
-elif [[ "$1" == "gcp-prod" ]]; then
-    export HOST=${GCP_PROD_HOST}
-
-else
-    echo "Unknown environment. Use 'aws-stage', 'aws-prod', 'gcp-stage', or 'gcp-prod'."
-    echo "Exiting."
-    exit 1
-fi
-
-LOCUST_FLAGS="--headless"
-
-mkdir logs || true
-
-# Runname includes environment and any second argument
-DATE="$(date +'%Y%m%d-%H0000')"
-
-echo ">>> Host:    ${HOST}"
-read -p "Ready to start? " nextvar
-
-# prime
+HOST="$(eliot_base_url "$1")"
 USERS="3"
 RUNTIME="5m"
-RUNNAME="${DATE}-$1$2-prime"
+RUNNAME_SUFFIX="$1$2-prime"
+run_loadtest
 
-echo "$(date): Locust start ${RUNNAME}...."
-locust -f locust-eliot/testfile.py \
-    --host="${HOST}" \
-    --users="${USERS}" \
-    --run-time="${RUNTIME}" \
-    --csv="logs/${RUNNAME}" \
-    ${LOCUST_FLAGS}
-echo "$(date): Locust end ${RUNNAME}."
-
-echo "${RUNNAME} users=${USERS} runtime=${RUNTIME}"
-python bin/print_locust_stats.py logs/${RUNNAME}
-read -p "Next? " nextvar
-
-# high
 USERS="5"
 RUNTIME="10m"
-RUNNAME="${DATE}-$1$2-high"
-
-echo "$(date): Locust start ${RUNNAME}...."
-locust -f locust-eliot/testfile.py \
-    --host="${HOST}" \
-    --users="${USERS}" \
-    --run-time="${RUNTIME}" \
-    --csv="logs/${RUNNAME}" \
-    ${LOCUST_FLAGS}
-echo "$(date): Locust end ${RUNNAME}."
-
-echo "${RUNNAME} users=${USERS} runtime=${RUNTIME}"
-python bin/print_locust_stats.py logs/${RUNNAME}
+RUNNAME_SUFFIX="$1$2-high"
+run_loadtest

--- a/locust-eliot/loadtest_eliot.sh
+++ b/locust-eliot/loadtest_eliot.sh
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Usage: ./loadtest_eliot.sh ENV [RUNNAME]
+# Run inside the Docker container.
 
 cd "$(dirname -- "$0")"
 . loadtest_functions.sh

--- a/locust-eliot/loadtest_functions.sh
+++ b/locust-eliot/loadtest_functions.sh
@@ -1,0 +1,43 @@
+# Common functions for the shell scripts in this directory
+
+# Return the Eliot base URL for the given environment
+eliot_base_url() {
+    case "$1" in
+        aws-stage)  echo "https://symbolication.stage.mozaws.net";;
+        aws-prod)   echo "https://symbolication.services.mozilla.com";;
+        gcp-stage)  echo "https://stage.eliot.nonprod.dataservices.mozgcp.net";;
+        gcp-prod)   echo "https://prod.eliot.prod.dataservices.mozgcp.net";;
+        *)
+            echo >&2 "Unknown environment. Use 'aws-stage', 'aws-prod', 'gcp-stage' or 'gcp-prod'."
+            echo >&2 "Exiting."
+            exit 1
+    esac
+}
+
+# Run the load test. Expects these variables to be set:
+#
+# HOST: the Eliot base URL
+# RUNNAME_SUFFIX: suffix appended to the log directory name
+# USERS: number of concurrent users
+# RUNTIME: duration of the load test
+run_loadtest() {
+    echo ">>> Host:    ${HOST}"
+
+    mkdir -p logs
+    LOCUST_FLAGS="${LOCUST_FLAGS:---headless}"
+    DATE="$(date +'%Y%m%d-%H0000')"
+    RUNNAME="${DATE}-${RUNNAME_SUFFIX}"
+
+    read -p "Ready to start? " nextvar
+    echo "$(date): Locust start ${RUNNAME}...."
+    locust -f testfile.py \
+        --host="${HOST}" \
+        --users="${USERS}" \
+        --run-time="${RUNTIME}" \
+        --csv="logs/${RUNNAME}" \
+        ${LOCUST_FLAGS}
+    echo "$(date): Locust end ${RUNNAME}."
+
+    echo "${RUNNAME} users=${USERS} runtime=${RUNTIME}"
+    python ../bin/print_locust_stats.py "logs/${RUNNAME}"
+}

--- a/locust-eliot/loadtest_functions.sh
+++ b/locust-eliot/loadtest_functions.sh
@@ -7,8 +7,10 @@ eliot_base_url() {
         aws-prod)   echo "https://symbolication.services.mozilla.com";;
         gcp-stage)  echo "https://stage.eliot.nonprod.dataservices.mozgcp.net";;
         gcp-prod)   echo "https://prod.eliot.prod.dataservices.mozgcp.net";;
+        gcp2-stage) echo "https://eliot-stage.symbols.nonprod.webservices.mozgcp.net";;
+        gcp2-prod)  echo "https://eliot-prod.symbols.prod.webservices.mozgcp.net";;
         *)
-            echo >&2 "Unknown environment. Use 'aws-stage', 'aws-prod', 'gcp-stage' or 'gcp-prod'."
+            echo >&2 "Unknown environment. Use 'aws-stage', 'aws-prod', 'gcp-stage', 'gcp-prod', 'gcp2-stage' or 'gcp2-prod'."
             echo >&2 "Exiting."
             exit 1
     esac

--- a/locust-eliot/loadtest_high.sh
+++ b/locust-eliot/loadtest_high.sh
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Usage: ./loadtest_high.sh ENV [RUNNAME]
+# Run inside the Docker container.
 
 cd "$(dirname -- "$0")"
 . loadtest_functions.sh

--- a/locust-eliot/loadtest_high.sh
+++ b/locust-eliot/loadtest_high.sh
@@ -5,57 +5,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Usage: ./loadtest_high.sh ENV [RUNNAME]
-#
-# Run it in the Docker container in the locust-eliot/ directory.
 
-AWS_STAGE_HOST="https://symbolication.stage.mozaws.net"
-AWS_PROD_HOST="https://symbolication.services.mozilla.com"
+cd "$(dirname -- "$0")"
+. loadtest_functions.sh
 
-GCP_STAGE_HOST="https://stage.eliot.nonprod.dataservices.mozgcp.net"
-GCP_PROD_HOST="https://prod.eliot.prod.dataservices.mozgcp.net"
-
-
-if [[ "$1" == "aws-stage" ]]; then
-    export HOST=${AWS_STAGE_HOST}
-
-elif [[ "$1" == "aws-prod" ]]; then
-    export HOST=${AWS_PROD_HOST}
-
-elif [[ "$1" == "gcp-stage" ]]; then
-    export HOST=${GCP_STAGE_HOST}
-
-elif [[ "$1" == "gcp-prod" ]]; then
-    export HOST=${GCP_PROD_HOST}
-
-else
-    echo "Unknown environment. Use 'aws-stage', 'aws-prod', 'gcp-stage', or 'gcp-prod'."
-    echo "Exiting."
-    exit 1
-fi
-
-LOCUST_FLAGS="--headless"
-
-mkdir logs || true
-
-# Runname includes environment and any second argument
-DATE="$(date +'%Y%m%d-%H0000')"
-
-echo ">>> Host:    ${HOST}"
-read -p "Ready to start? " nextvar
-
-# high
+HOST="$(eliot_base_url "$1")"
 USERS="10"
 RUNTIME="10m"
-RUNNAME="${DATE}-$1$2-high"
-
-echo "$(date): Locust start ${RUNNAME}...."
-locust -f locust-eliot/testfile.py \
-    --host="${HOST}" \
-    --users="${USERS}" \
-    --run-time="${RUNTIME}" \
-    --csv="logs/${RUNNAME}" \
-    ${LOCUST_FLAGS}
-echo "$(date): Locust end ${RUNNAME}."
-
-echo "${RUNNAME} users=${USERS} runtime=${RUNTIME}"
-python bin/print_locust_stats.py logs/${RUNNAME}
+RUNNAME_SUFFIX="$1$2-high"
+run_loadtest

--- a/locust-eliot/loadtest_normal.sh
+++ b/locust-eliot/loadtest_normal.sh
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Usage: ./loadtest_normal.sh ENV [RUNNAME]
+# Run inside the Docker container.
 
 cd "$(dirname -- "$0")"
 . loadtest_functions.sh

--- a/locust-eliot/loadtest_normal.sh
+++ b/locust-eliot/loadtest_normal.sh
@@ -5,57 +5,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Usage: ./loadtest_normal.sh ENV [RUNNAME]
-#
-# Run it in the Docker container in the locust-eliot/ directory.
 
-AWS_STAGE_HOST="https://symbolication.stage.mozaws.net"
-AWS_PROD_HOST="https://symbolication.services.mozilla.com"
+cd "$(dirname -- "$0")"
+. loadtest_functions.sh
 
-GCP_STAGE_HOST="https://stage.eliot.nonprod.dataservices.mozgcp.net"
-GCP_PROD_HOST="https://prod.eliot.prod.dataservices.mozgcp.net"
-
-
-if [[ "$1" == "aws-stage" ]]; then
-    export HOST=${AWS_STAGE_HOST}
-
-elif [[ "$1" == "aws-prod" ]]; then
-    export HOST=${AWS_PROD_HOST}
-
-elif [[ "$1" == "gcp-stage" ]]; then
-    export HOST=${GCP_STAGE_HOST}
-
-elif [[ "$1" == "gcp-prod" ]]; then
-    export HOST=${GCP_PROD_HOST}
-
-else
-    echo "Unknown environment. Use 'aws-stage', 'aws-prod', 'gcp-stage', or 'gcp-prod'."
-    echo "Exiting."
-    exit 1
-fi
-
-LOCUST_FLAGS="--headless"
-
-mkdir logs || true
-
-# Runname includes environment and any second argument
-DATE="$(date +'%Y%m%d-%H0000')"
-
-echo ">>> Host:    ${HOST}"
-read -p "Ready to start? " nextvar
-
-# normal load
+HOST="$(eliot_base_url "$1")"
 USERS="3"
 RUNTIME="30m"
-RUNNAME="${DATE}-$1$2-normal"
-
-echo "$(date): Locust start ${RUNNAME}...."
-locust -f locust-eliot/testfile.py \
-    --host="${HOST}" \
-    --users="${USERS}" \
-    --run-time="${RUNTIME}" \
-    --csv="logs/${RUNNAME}" \
-    ${LOCUST_FLAGS}
-echo "$(date): Locust end ${RUNNAME}."
-
-echo "${RUNNAME} users=${USERS} runtime=${RUNTIME}"
-python bin/print_locust_stats.py logs/${RUNNAME}
+RUNNAME_SUFFIX="$1$2-normal"
+run_loadtest

--- a/locust-eliot/prime_env.sh
+++ b/locust-eliot/prime_env.sh
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Usage: ./prime_env.sh ENV [RUNNAME]
+# Run inside the Docker container.
 
 cd "$(dirname -- "$0")"
 . loadtest_functions.sh

--- a/locust-eliot/prime_env.sh
+++ b/locust-eliot/prime_env.sh
@@ -5,57 +5,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Usage: ./prime_env.sh ENV [RUNNAME]
-#
-# Run it in the Docker container in the locust-eliot/ directory.
 
-AWS_STAGE_HOST="https://symbolication.stage.mozaws.net"
-AWS_PROD_HOST="https://symbolication.services.mozilla.com"
+cd "$(dirname -- "$0")"
+. loadtest_functions.sh
 
-GCP_STAGE_HOST="https://stage.eliot.nonprod.dataservices.mozgcp.net"
-GCP_PROD_HOST="https://prod.eliot.prod.dataservices.mozgcp.net"
-
-
-if [[ "$1" == "aws-stage" ]]; then
-    export HOST=${AWS_STAGE_HOST}
-
-elif [[ "$1" == "aws-prod" ]]; then
-    export HOST=${AWS_PROD_HOST}
-
-elif [[ "$1" == "gcp-stage" ]]; then
-    export HOST=${GCP_STAGE_HOST}
-
-elif [[ "$1" == "gcp-prod" ]]; then
-    export HOST=${GCP_PROD_HOST}
-
-else
-    echo "Unknown environment. Use 'aws-stage', 'aws-prod', 'gcp-stage', or 'gcp-prod'."
-    echo "Exiting."
-    exit 1
-fi
-
-LOCUST_FLAGS="--headless"
-
-mkdir logs || true
-
-# Runname includes environment and any second argument
-DATE="$(date +'%Y%m%d-%H0000')"
-
-echo ">>> Host:    ${HOST}"
-read -p "Ready to start? " nextvar
-
-# prime
+HOST="$(eliot_base_url "$1")"
 USERS="2"
 RUNTIME="10m"
-RUNNAME="${DATE}-$1$2-prime"
-
-echo "$(date): Locust start ${RUNNAME}...."
-locust -f testfile.py \
-    --host="${HOST}" \
-    --users="${USERS}" \
-    --run-time="${RUNTIME}" \
-    --csv="logs/${RUNNAME}" \
-    ${LOCUST_FLAGS}
-echo "$(date): Locust end ${RUNNAME}."
-
-echo "${RUNNAME} users=${USERS} runtime=${RUNTIME}"
-python ../bin/print_locust_stats.py logs/${RUNNAME}
+RUNNAME_SUFFIX="$1$2-prime"
+run_loadtest


### PR DESCRIPTION
My main goal was adding the new environments. Since the load test shell scripts had a bit too much code duplication for my taste, I first did a quick pass factoring out the common code into shell functions.

There's more clean-up that cold be done here, like adding `set -euo pipefail` to the scripts, but since this repository is rarely used, I didn't want to spend too much time on this.

The scripts all stated "Run it in the Docker container in the locust-eliot/ directory." in a comment. However, some of the scripts were written to be run from the root directory of the repo. The new versions of the scripts can be run from any directory – they simply cd to the directory the script is located in first. I adjusted the comments accordingly. The README still asks to first cd to the `locust-eliot` directory, but since that works, I'll just leave it at that.